### PR TITLE
 Resources should be closed

### DIFF
--- a/src/org/kefirsf/bb/ConfigurationFactory.java
+++ b/src/org/kefirsf/bb/ConfigurationFactory.java
@@ -187,17 +187,20 @@ public class ConfigurationFactory {
      * @throws TextProcessorFactoryException any problems
      */
     public Configuration create(File file) {
+        InputStream stream = null;
         try {
             Configuration configuration;
-            InputStream stream = new BufferedInputStream(new FileInputStream(file));
-            try {
-                configuration = create(stream);
-            } finally {
-                stream.close();
-            }
-            return configuration;
+            stream = new BufferedInputStream(new FileInputStream(file));
+            return create(stream);
         } catch (IOException e) {
             throw new TextProcessorFactoryException(e);
+        } finally {
+            try {
+                if(stream == null)
+                    stream.close();
+            } catch (IOException e) {
+                throw new TextProcessorFactoryException(e);
+            }
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “ Resources should be closed”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.