### PR TITLE
Allow more characters in the path of a url.

### DIFF
--- a/src/org/kefirsf/bb/proc/ProcUrl.java
+++ b/src/org/kefirsf/bb/proc/ProcUrl.java
@@ -12,14 +12,18 @@ import java.util.regex.Pattern;
  * @author kefir
  */
 public class ProcUrl extends AbstractUrl {
+
+    private static final String pct_encoded = "(%\\p{XDigit}{2})";
+    private static final String pchar = "[\\w~!$&'*+,;=:@\\(\\)\\.\\-]|"+pct_encoded;
+
     private static final Pattern REGEX_PORT = Pattern.compile(
             ":\\d{1,4}"
     );
     private static final Pattern REGEX_PATH = Pattern.compile(
-            "(/([\\w\\(\\)\\.\\-]|(%\\p{XDigit}{2}))+)*/?"
+            "(/(" + pchar + ")+)*/?"
     );
     private static final Pattern REGEX_FRAGMENT = Pattern.compile(
-            "#([\\w&\\-=]|(%\\p{XDigit}{2}))*"
+            "#(" + pchar + "|[/?])*"
     );
     private static final Pattern REGEX_LOCAL_PREFIX = Pattern.compile("\\.{0,2}/");
 

--- a/test/org/kefirsf/bb/proc/ProcUrlMethodTest.java
+++ b/test/org/kefirsf/bb/proc/ProcUrlMethodTest.java
@@ -62,7 +62,7 @@ public class ProcUrlMethodTest {
     @Test
     public void testParsePath(){
         String[] paths = new String[]{
-                "", "/", "/home", "/home/", "/home/web"
+                "", "/", "/home", "/home/", "/home/web", "/AZaz09-._~!$&'()*+,;=:@"
         };
 
         for(String path: paths) {


### PR DESCRIPTION
Urls with paths containing non-alphanumeric characters like '&' which are allowed by [RFC3986](https://tools.ietf.org/html/rfc3986#section-3.3) are not parsed correcly.

A path segment (the parts in a path separated by /) in an absolute URI path can contain zero or more of pchar that is defined as follows:

  pchar       = unreserved / pct-encoded / sub-delims / ":" / "@"
  pct-encoded = "%" HEXDIG HEXDIG
  unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
  sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="